### PR TITLE
Prevent bot wars by printing a leading space

### DIFF
--- a/lib/Geth/Plugin/GitHub.pm6
+++ b/lib/Geth/Plugin/GitHub.pm6
@@ -121,5 +121,5 @@ sub karma-name {
 }
 
 sub prefix-lines ($pref, *@text) {
-    join "\n", map {"$pref: $_"}, @text.join("\n").lines;
+    join "\n", map {" $pref: $_"}, @text.join("\n").lines;
 }


### PR DESCRIPTION
Otherwise its messages look like this:

    <Geth> nqp: meowmeow | (fake Zoffix)++ | fakety.fake

｢nqp:｣ actually triggers camelia, so camelia has to ignore Geth. However,
there are other bots that may eventually start being triggered by commit
announces (whateverable comes to mind).

Instead of making every bot out there ignore Geth, let's make sure that Geth
prints stuff in a way that won't possibly trigger any other bot.

    <geekosaur> the usual convention is output a leading space, then bots ignore anything
    with a leading space. or use /notify for output and bots only accept commands
    via /msg (remembering that channel messages are /msg #chan)