### PR TITLE
Update webhook endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ can be restarted with:
 
     sudo service geth restart
 
-The webhook endpoint is `http://hack.p6c.org:8888/?chan=#perl6` where `#perl6`
+The webhook endpoint is `https://geth.svc.tyil.net/?chan=#perl6` where `#perl6`
 is the channel to report the commits to. Multiple channels can be specified,
 separated with commas.
 

--- a/bin/geth.p6
+++ b/bin/geth.p6
@@ -11,7 +11,7 @@ class Geth::Plugin::Info {
     multi method irc-to-me ($ where /^ \s* ['help' | 'source' ] '?'? \s* $/) {
         "Source at https://github.com/perl6/geth "
         ~ "To add repo, add an 'application/json' webhook on GitHub "
-        ~ "pointing it to https://svc.tyil.net/?chan=%23perl6 and choose "
+        ~ "pointing it to https://geth.svc.tyil.net/?chan=%23perl6 and choose "
         ~ "'Send me everything' for events to send | use `ver URL to commit` "
         ~ "to fetch version bump changes";
     }


### PR DESCRIPTION
The documentation for the endpoint URL was incorrect, as Geth no longer runs on `hack.p6c.org`. The updated URL no longer needs an explicit port defined, but one does need to update the protocol from `http` to `https`. As far as I know, this is already the case for all webhooks currently making use of Geth.